### PR TITLE
chore: Update Dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,11 +23,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
       - name: Validate Gradle Wrapper
-        uses: gradle/wrapper-validation-action@v1
+        uses: gradle/wrapper-validation-action@v2
       - name: Setup JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: 17
@@ -35,7 +35,7 @@ jobs:
       - name: Build APK
         run: bash ./gradlew assembleReleaseGithub --stacktrace
       - name: Upload APK
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: release
           path: app/build/outputs/apk/releaseGithub/

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     id("com.android.application")
     kotlin("android")
     id("com.google.devtools.ksp")
-    kotlin("plugin.serialization") version "1.8.21"
+    kotlin("plugin.serialization") version "1.9.22"
 }
 
 android {
@@ -63,7 +63,7 @@ android {
         compose = true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion = "1.4.7"
+        kotlinCompilerExtensionVersion = "1.5.9"
     }
     packaging {
         resources {
@@ -73,9 +73,9 @@ android {
 }
 
 dependencies {
-    implementation("androidx.core:core-ktx:1.10.1")
-    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.6.1")
-    implementation("androidx.activity:activity-compose:1.7.1")
+    implementation("androidx.core:core-ktx:1.12.0")
+    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.7.0")
+    implementation("androidx.activity:activity-compose:1.8.2")
     implementation(platform("androidx.compose:compose-bom:2023.05.01"))
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.ui:ui-graphics")
@@ -84,19 +84,19 @@ dependencies {
 
     debugImplementation("androidx.compose.ui:ui-tooling")
 
-    implementation("androidx.compose.material3:material3-window-size-class:1.1.0")
+    implementation("androidx.compose.material3:material3-window-size-class:1.2.0")
 
-    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.6.1")
-    implementation("androidx.navigation:navigation-compose:2.7.0-alpha01")
-    implementation("androidx.compose.material:material-icons-extended:1.4.3")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.7.0")
+    implementation("androidx.navigation:navigation-compose:2.7.7")
+    implementation("androidx.compose.material:material-icons-extended:1.6.1")
 
     // Coil
-    implementation("io.coil-kt:coil-compose:2.3.0")
-    implementation("io.coil-kt:coil-svg:2.3.0")
+    implementation("io.coil-kt:coil-compose:2.5.0")
+    implementation("io.coil-kt:coil-svg:2.5.0")
     implementation("androidx.appcompat:appcompat:1.6.1")
 
     // Room
-    val roomVersion = "2.5.1"
+    val roomVersion = "2.6.1"
 
     implementation("androidx.room:room-runtime:$roomVersion")
     implementation("androidx.room:room-ktx:$roomVersion")
@@ -104,7 +104,7 @@ dependencies {
     ksp("androidx.room:room-compiler:$roomVersion")
 
     implementation("com.squareup.retrofit2:retrofit:2.9.0")
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.0")
     implementation("com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter:1.0.0")
 
     implementation("com.github.yuriy-budiyev:code-scanner:2.3.2")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -77,12 +77,12 @@ dependencies {
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.7.0")
     implementation("androidx.activity:activity-compose:1.8.2")
     implementation(platform("androidx.compose:compose-bom:2024.02.00"))
-    implementation("androidx.compose.ui:ui")
-    implementation("androidx.compose.ui:ui-graphics")
-    implementation("androidx.compose.ui:ui-tooling-preview")
-    implementation("androidx.compose.material3:material3")
+    implementation("androidx.compose.ui:ui:1.6.1")
+    implementation("androidx.compose.ui:ui-graphics:1.6.1")
+    implementation("androidx.compose.ui:ui-tooling-preview:1.6.1")
+    implementation("androidx.compose.material3:material3:1.2.0")
 
-    debugImplementation("androidx.compose.ui:ui-tooling")
+    debugImplementation("androidx.compose.ui:ui-tooling:1.6.1")
 
     implementation("androidx.compose.material3:material3-window-size-class:1.2.0")
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -76,7 +76,7 @@ dependencies {
     implementation("androidx.core:core-ktx:1.12.0")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.7.0")
     implementation("androidx.activity:activity-compose:1.8.2")
-    implementation(platform("androidx.compose:compose-bom:2023.05.01"))
+    implementation(platform("androidx.compose:compose-bom:2024.02.00"))
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.ui:ui-graphics")
     implementation("androidx.compose.ui:ui-tooling-preview")
@@ -104,7 +104,7 @@ dependencies {
     ksp("androidx.room:room-compiler:$roomVersion")
 
     implementation("com.squareup.retrofit2:retrofit:2.9.0")
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.2")
     implementation("com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter:1.0.0")
 
     implementation("com.github.yuriy-budiyev:code-scanner:2.3.2")

--- a/app/src/main/java/app/suhasdissa/foode/ui/screens/AboutScreen.kt
+++ b/app/src/main/java/app/suhasdissa/foode/ui/screens/AboutScreen.kt
@@ -66,7 +66,7 @@ fun AboutScreen(
                             "https://github.com/SuhasDissa/Food-E-App/issues"
                         )
                     },
-                    icon = Icons.Default.ContactSupport
+                    icon = Icons.AutoMirrored.Default.ContactSupport
                 )
             }
             item {

--- a/app/src/main/java/app/suhasdissa/foode/ui/screens/AboutScreen.kt
+++ b/app/src/main/java/app/suhasdissa/foode/ui/screens/AboutScreen.kt
@@ -3,7 +3,7 @@ package app.suhasdissa.foode.ui.screens
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ContactSupport
+import androidx.compose.material.icons.automirrored.filled.ContactSupport
 import androidx.compose.material.icons.filled.Description
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.NewReleases

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,8 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id("com.android.application") version "8.0.0" apply false
-    id("com.android.library") version "8.0.0" apply false
-    id("org.jetbrains.kotlin.android") version "1.8.21" apply false
-    id("com.google.devtools.ksp") version "1.8.21-1.0.11" apply false
+    id("com.android.application") version "8.2.2" apply false
+    id("com.android.library") version "8.2.2" apply false
+    id("org.jetbrains.kotlin.android") version "1.9.22" apply false
+    id("com.google.devtools.ksp") version "1.9.22-1.0.17" apply false
 
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=4159b938ec734a8388ce03f52aa8f3c7ed0d31f5438622545de4f83a89b79788
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionSha256Sum=9631d53cf3e74bfa726893aee1f8994fee4e060c401335946dba2156f440f24c
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This PR updates:

#### Github Actions

- [actions/checkout@v1](https://github.com/actions/checkout/releases/tag/v1) -> [@v4](https://github.com/actions/checkout/releases/tag/v4)
- [actions/setup-java@v3](https://github.com/actions/setup-java/releases/tag/v3) -> [@v4](https://github.com/actions/setup-java/releases/tag/v4)
- [actions/upload-artifact@v1](https://github.com/actions/upload-artifact/releases/tag/v1) -> [@v4](https://github.com/actions/upload-artifact/releases/tag/v4)
- [gradle/wrapper-validation-action@v1](https://github.com/gradle/wrapper-validation-action/releases/tag/v1) -> [@v2](https://github.com/gradle/wrapper-validation-action/releases/tag/v2)

#### Android Dependencies:

- [Android Gradle Plugin 8.0.0](https://mvnrepository.com/artifact/com.android.application/com.android.application.gradle.plugin/8.0.0) -> [8.2.2](https://mvnrepository.com/artifact/com.android.application/com.android.application.gradle.plugin/8.2.2)
- [Coil Kotlin 2.3.0](https://github.com/coil-kt/coil/blob/main/CHANGELOG.md#230---march-25-2023) -> [2.5.0](https://github.com/coil-kt/coil/blob/main/CHANGELOG.md#250---october-30-2023)
- [Gradle 8.0](https://docs.gradle.org/8.0/release-notes.html) -> [8.6](https://docs.gradle.org/8.6/release-notes.html)
- [Kotlin 1.8.21](https://github.com/JetBrains/kotlin/releases/tag/v1.8.21) -> [1.9.22](https://github.com/JetBrains/kotlin/releases/tag/v1.9.22)
- [Kotlin Serialization Plugin 1.8.21-1.0.11](https://github.com/google/ksp/releases/tag/1.8.21-1.0.11) -> [1.9.22-1.0.17](https://github.com/google/ksp/releases/tag/1.9.22-1.0.17)
  - [Kotlin JSON Serialization Plugin 1.5.0](https://github.com/Kotlin/kotlinx.serialization/releases/tag/v1.5.0) -> [1.6.2](https://github.com/Kotlin/kotlinx.serialization/releases/tag/v1.6.2)
- [Jetpack Compose BOM 2023.05.01](https://mvnrepository.com/artifact/androidx.compose/compose-bom/2023.05.01) -> [2024.02.00](https://mvnrepository.com/artifact/androidx.compose/compose-bom/2024.02.00)
- [Jetpack Compose Compiler 1.4.7](https://developer.android.com/jetpack/androidx/releases/compose-compiler#1.4.7) -> [1.5.9](https://developer.android.com/jetpack/androidx/releases/compose-compiler#1.5.9)
- [Jetpack Compose Material3 1.1.0](https://developer.android.com/jetpack/androidx/releases/compose-material3#1.1.0) -> [1.2.0](https://developer.android.com/jetpack/androidx/releases/compose-material3#1.2.0)
- [Jetpack Compose Material Icons 1.4.3](https://developer.android.com/jetpack/androidx/releases/compose-material#1.4.3) -> [1.6.1](https://developer.android.com/jetpack/androidx/releases/compose-material#1.6.1)
- Jetpack Compose UI unset -> [1.6.1](https://developer.android.com/jetpack/androidx/releases/compose-ui#1.6.1)
- [Jetpack Lifecycle 2.6.1](https://developer.android.com/jetpack/androidx/releases/lifecycle#2.6.1) -> [2.7.0](https://developer.android.com/jetpack/androidx/releases/lifecycle#2.7.0)
- [Jetpack Navigation 2.7.0-alpha01](https://developer.android.com/jetpack/androidx/releases/navigation#2.7.0-alpha01) -> [2.7.7](https://developer.android.com/jetpack/androidx/releases/navigation#version_277_3)
- [Jetpack Room 2.5.1](https://developer.android.com/jetpack/androidx/releases/room#2.5.1) -> [2.6.1](https://developer.android.com/jetpack/androidx/releases/room#2.6.1)

It also fixes the Deprecation Warning for the ContactSupport Material Icon.